### PR TITLE
Use absolute path for entrypoint script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,6 +55,4 @@ COPY install_spark_packages.py ${AIRFLOW_HOME}/install_spark_packages.py
 RUN gosu "${USER}" python install_spark_packages.py
 
 COPY docker/entrypoint.sh ${AIRFLOW_HOME}/entrypoint.sh
-ENTRYPOINT ["./entrypoint.sh"]
-
-# CMD ["airflow", "webserver"]
+ENTRYPOINT "${AIRFLOW_HOME}/entrypoint.sh"


### PR DESCRIPTION
If inherited images change `WORKDIR`, this will not break

__Not sure if this will break with `CMD` because of the weird way it works. Please test, if possible__