### PR TITLE
Change ENTRYPOINT to `exec` form so that CMD can be run

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,5 +54,5 @@ COPY setup_auth.py ${AIRFLOW_HOME}/setup_auth.py
 COPY install_spark_packages.py ${AIRFLOW_HOME}/install_spark_packages.py
 RUN gosu "${USER}" python install_spark_packages.py
 
-COPY docker/entrypoint.sh ${AIRFLOW_HOME}/entrypoint.sh
-ENTRYPOINT "${AIRFLOW_HOME}/entrypoint.sh"
+COPY docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
+cd ${AIRFLOW_HOME}
 export SPARK_DIST_CLASSPATH=$(hadoop classpath)
 POSTGRES_TIMEOUT=60
 
@@ -37,7 +38,6 @@ gosu "${USER}" sed -i "/\(^dag_concurrency = \).*/ s//\1${AIRFLOW_DAG_CONCURRENC
 gosu "${USER}" sed -i "/\(^max_threads = \).*/ s//\1${AIRFLOW_DAG_CONCURRENCY}/" ${AIRFLOW_HOME}/airflow.cfg
 gosu "${USER}" airflow initdb # https://groups.google.com/forum/#!topic/airbnb_airflow/4ZGWUzKkBbw
 
-cd ${AIRFLOW_HOME}
 if [ "$1" = 'afp-scheduler' ]; then
     (airflow list_dags | grep '^fn_') | while read fn_dag; do
         echo "Back filling DAG ${fn_dag}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,6 +37,7 @@ gosu "${USER}" sed -i "/\(^dag_concurrency = \).*/ s//\1${AIRFLOW_DAG_CONCURRENC
 gosu "${USER}" sed -i "/\(^max_threads = \).*/ s//\1${AIRFLOW_DAG_CONCURRENCY}/" ${AIRFLOW_HOME}/airflow.cfg
 gosu "${USER}" airflow initdb # https://groups.google.com/forum/#!topic/airbnb_airflow/4ZGWUzKkBbw
 
+cd ${AIRFLOW_HOME}
 if [ "$1" = 'afp-scheduler' ]; then
     (airflow list_dags | grep '^fn_') | while read fn_dag; do
         echo "Back filling DAG ${fn_dag}"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-cd ${AIRFLOW_HOME}
 export SPARK_DIST_CLASSPATH=$(hadoop classpath)
 POSTGRES_TIMEOUT=60
 


### PR DESCRIPTION
 - Fixes CMD being ignored
 - Copy entrypoint script to root because exec form does not understand env variables

See https://docs.docker.com/engine/reference/builder/#/entrypoint