### PR TITLE
Runnable build

### DIFF
--- a/Dockerfile-runnable
+++ b/Dockerfile-runnable
@@ -1,0 +1,2 @@
+FROM datagovsg/airflow-pipeline:latest
+MAINTAINER Chris Sng <chris@data.gov.sg>

--- a/docker-compose.macvlan.yml
+++ b/docker-compose.macvlan.yml
@@ -13,7 +13,9 @@ services:
       POSTGRES_DB: airflow
       TZ: "Asia/Singapore"
   scheduler:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-runnable
     networks:
       - afpnet
     restart: always
@@ -36,7 +38,9 @@ services:
     volumes:
       - airflow_logs:/airflow/logs
   webserver:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-runnable
     networks:
       - afpnet
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,9 @@ services:
       POSTGRES_DB: airflow
       TZ: "Asia/Singapore"
   scheduler:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-runnable
     network_mode: "host"
     restart: always
     depends_on:
@@ -34,7 +36,9 @@ services:
     volumes:
       - airflow_logs:/airflow/logs
   webserver:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile-runnable
     network_mode: "host"
     restart: always
     depends_on:


### PR DESCRIPTION
- Existing `Dockerfile` has `ONBUILD` instructions which will only be executed in subsequent builds
- Therefore, add an empty `Dockerfile-runnable` to execute them
- Run using `docker-compose -f docker-compose.yml up --build -d`