### PR TITLE
Fix SqlAlchemy add password issue and required use of Fernet key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends -y vim-tiny libsasl2-dev libffi-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==1.9.0" psycopg2
+    && pip install --no-cache-dir "git+git://github.com/apache/incubator-airflow.git@5e4d7d8d7da250cacc15d8a2247098f0b42a3def#egg=apache-airflow[devel_hadoop, crypto]" psycopg2
 
 ENV AIRFLOW_HOME /airflow
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,6 +3,10 @@ services:
   scheduler:
     volumes:
       - ./dags:/airflow/dags
+    environment:
+      AIRFLOW__CORE__FERNET_KEY: 8NE6O6RcTJpxcCkuKxOHOExzIJkXkeJKbRie03a69dI=
   webserver:
     volumes:
       - ./dags:/airflow/dags
+    environment:
+      AIRFLOW__CORE__FERNET_KEY: 8NE6O6RcTJpxcCkuKxOHOExzIJkXkeJKbRie03a69dI=


### PR DESCRIPTION
SqlAlchemy add password issue:
https://issues.apache.org/jira/browse/AIRFLOW-1966

Tested using the following commands upon `git clone`:
1. `docker build . -t datagovsg/airflow-pipeline`
2. `docker-compose -f docker-compose.yml -f docker-compose.override.yml up --build -d`