### PR TITLE
Airflow 1.9 with SQLAlchemy 1.1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN set -ex \
     && apt-get update \
     && apt-get install --no-install-recommends -y vim-tiny libsasl2-dev libffi-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==1.8.2" psycopg2
+    && pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==1.9.0" psycopg2 \
+    && pip install --no-cache-dir sqlalchemy==1.1.17
 
 ENV AIRFLOW_HOME /airflow
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An [Airflow](https://airflow.incubator.apache.org/) setup that aims to work well
 This image is based off the [`python-spark`](https://github.com/datagovsg/python-spark) image and contains standard Python, Hadoop and Spark installations.
 
 - <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/Python-logo-notext.svg/240px-Python-logo-notext.svg.png" height="20"> Python 2.7
-- <img src="https://airflow.incubator.apache.org/_images/pin_large.png" height="20"> Airflow 1.8.2 (with PostgreSQL 9.6)
+- <img src="https://airflow.incubator.apache.org/_images/pin_large.png" height="20"> Airflow 1.9 (with PostgreSQL 9.6)
 - <img src="http://spark.apache.org/images/spark-logo-trademark.png" height="24"> Spark 1.6.1
 - <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Hadoop_logo.svg/320px-Hadoop_logo.svg.png" height="20"> Hadoop 2.6
 - <img src="https://upload.wikimedia.org/wikipedia/commons/b/b4/Apache_Sqoop_logo.svg" height="16"> Sqoop 1.4.6 (with JDBC connectors for PostgreSQL, MySQL and SQL Server)


### PR DESCRIPTION
- Use latest airflow with older sqlalchemy package (Airflow 1.9 require at least Sqlalchemy 0.9.8)
- Until SqlAlchemy issue is fixed: https://issues.apache.org/jira/browse/AIRFLOW-1966