### PR TITLE
Make onbuild dag copy optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 
-FROM no-spark AS with-spark
+FROM no-spark AS with-spark-optional-dag
 
 # Install Java
 RUN apt-get update \
@@ -96,7 +96,7 @@ RUN ["/bin/bash", "-c", "set -eoux pipefail && \
 COPY log4j.properties.production ${SPARK_HOME}/conf/log4j.properties
 
 
-FROM with-spark AS with-spark-onbuild
+FROM with-spark-optional-dag AS with-spark
 
 ## To build your own image:
 ONBUILD COPY dags/ ${AIRFLOW_DAG}

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,5 +95,8 @@ RUN ["/bin/bash", "-c", "set -eoux pipefail && \
 # Less verbose logging
 COPY log4j.properties.production ${SPARK_HOME}/conf/log4j.properties
 
+
+FROM with-spark AS with-spark-onbuild
+
 ## To build your own image:
 ONBUILD COPY dags/ ${AIRFLOW_DAG}


### PR DESCRIPTION
While `ONBUILD COPY dags/` help to ensure that `dags/` must be present to prevent mistake (which is a good thing), it is costly if the user has another child Dockerfile (FROM this Dockerfile) that performs some repository update and installation.

When the user performs a build after making some modification to his DAG files, which is likely to be common since it is the directory with the source code, it would result in unnecessary repository update and installation even though only the DAG source code files were changed.

Make the `ONBUILD COPY` optional by bringing it into another stage. This is similar to how <https://hub.docker.com/r/fluent/fluentd/tags/> works.