### PR TITLE
Update airflow.cfg to v1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,13 @@
 FROM python:2.7 AS no-spark
 LABEL maintainer="Chris Sng <chris@data.gov.sg>"
 
-ARG airflow_version=1.10.0
-ENV AIRFLOW_VERSION=${airflow_version}
-
 # Setup airflow
 RUN set -ex \
     && (echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list) \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --force-yes vim-tiny libsasl2-dev libffi-dev gosu krb5-user \
     && rm -rf /var/lib/apt/lists/* \
-    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==${AIRFLOW_VERSION}" psycopg2
+    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==1.10.0" psycopg2
 
 ARG airflow_home=/airflow
 ENV AIRFLOW_HOME=${airflow_home}

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ ENV PYSPARK_SUBMIT_ARGS="--driver-memory 8g --py-files ${SPARK_HOME}/python/lib/
 # Download Spark
 ARG SPARK_EXTRACT_LOC=/sparkbin
 RUN ["/bin/bash", "-c", "set -eoux pipefail && \
-    (curl https://www.mirrorservice.org/sites/ftp.apache.org/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
+    (curl https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
     tar -xz -C /opt/) && \
     mv /opt/hadoop-${HADOOP_VERSION} /opt/hadoop && \
     mkdir -p ${SPARK_EXTRACT_LOC} && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:2.7 AS no-spark
 LABEL maintainer="Chris Sng <chris@data.gov.sg>"
 
+ARG airflow_version=1.10.0
+ENV AIRFLOW_VERSION=${airflow_version}
+
 # Setup airflow
 RUN set -ex \
     && (echo 'deb http://deb.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list) \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y --force-yes vim-tiny libsasl2-dev libffi-dev gosu krb5-user \
     && rm -rf /var/lib/apt/lists/* \
-    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==1.10.0" psycopg2
+    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto]==${AIRFLOW_VERSION}" psycopg2
 
 ARG airflow_home=/airflow
 ENV AIRFLOW_HOME=${airflow_home}

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -11,20 +11,18 @@ dags_folder = /airflow/dags
 # This path must be absolute
 base_log_folder = /airflow/logs
 
-# Airflow can store logs remotely in AWS S3 or Google Cloud Storage. Users
-# must supply a remote location URL (starting with either 's3://...' or
-# 'gs://...') and an Airflow connection id that provides access to the storage
-# location.
+# Airflow can store logs remotely in AWS S3, Google Cloud Storage or Elastic Search.
+# Users must supply an Airflow connection id that provides access to the storage
+# location. If remote_logging is set to true, see UPDATING.md for additional
+# configuration requirements.
+remote_logging = False
 remote_base_log_folder =
 remote_log_conn_id =
-# Use server-side encryption for logs stored in S3
 encrypt_s3_logs = False
-# DEPRECATED option for remote log storage, use remote_base_log_folder instead!
-s3_log_folder =
 
 # Default timezone in case supplied date times are naive
 # can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
-default_timezone = system
+default_timezone = utc
 
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
@@ -104,6 +102,17 @@ endpoint_url = http://localhost:8080
 # How to authenticate users of the API
 auth_backend = airflow.api.auth.backend.default
 
+[lineage]
+# what lineage backend to use
+backend =
+
+[atlas]
+sasl_enabled = False
+host =
+port = 21000
+username =
+password =
+
 [operators]
 # The default owner assigned to each new operator, unless
 # provided explicitly or passed via `default_args`
@@ -113,6 +122,12 @@ default_ram = 512
 default_disk = 512
 default_gpus = 0
 
+[hive]
+# Default mapreduce queue for HiveOperator tasks
+default_hive_mapred_queue =
+# Template for mapred_job_name in HiveOperator, supports the following named parameters:
+# hostname, dag_id, task_id, execution_date
+mapred_job_name_template = Airflow HiveOperator task for {{hostname}}.{{dag_id}}.{{task_id}}.{{execution_date}}
 
 [webserver]
 # The base url of your website as airflow cannot guess what domain or
@@ -247,6 +262,35 @@ flower_port = 5555
 default_queue = default
 
 
+[celery_broker_transport_options]
+# This section is for specifying options which can be passed to the
+# underlying celery broker transport.  See:
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_transport_options
+
+# The visibility timeout defines the number of seconds to wait for the worker
+# to acknowledge the task before the message is redelivered to another worker.
+# Make sure to increase the visibility timeout to match the time of the longest
+# ETA you're planning to use.
+#
+# visibility_timeout is only supported for Redis and SQS celery brokers.
+# See:
+#   http://docs.celeryproject.org/en/master/userguide/configuration.html#std:setting-broker_transport_options
+#
+#visibility_timeout = 21600
+
+
+[dask]
+# This section only applies if you are using the DaskExecutor in
+# [core] section above
+
+# The IP address and port of the Dask cluster's scheduler.
+cluster_address = 127.0.0.1:8786
+# TLS/ SSL settings to access a secured Dask scheduler.
+tls_ca =
+tls_cert =
+tls_key =
+
+
 [scheduler]
 # Task instances listen for external kill signal (when you clear tasks
 # from the CLI or the UI), this defines the frequency at which they should
@@ -285,6 +329,18 @@ scheduler_zombie_task_threshold = 300
 # DAG definition (catchup)
 catchup_by_default = False
 
+# This changes the batch size of queries in the scheduling main loop.
+# If this is too high, SQL query performance may be impacted by one
+# or more of the following:
+#  - reversion to full table scan
+#  - complexity of query predicate
+#  - excessive locking
+#
+# Additionally, you may hit the maximum allowable query length for your db.
+#
+# Set this to 0 for no limit (not advised)
+max_tis_per_query = 512
+
 # Statsd (https://github.com/etsy/statsd) integration settings
 statsd_on = False
 statsd_host = localhost
@@ -298,6 +354,20 @@ max_threads = 2
 
 authenticate = False
 
+
+[ldap]
+# set this to ldaps://<your.ldap.server>:<port>
+uri =
+user_filter = objectClass=*
+user_name_attr = uid
+group_member_attr = memberOf
+superuser_filter =
+data_profiler_filter =
+bind_user = cn=Manager,dc=example,dc=com
+bind_password = insecure
+basedn = dc=example,dc=com
+cacert = /etc/ca/ldap_ca.crt
+search_scope = LEVEL
 
 [mesos]
 # Mesos master address which MesosExecutor will connect to.
@@ -336,6 +406,10 @@ authenticate = False
 # default_principal = admin
 # default_secret = admin
 
+# Optional Docker Image to run on slave before running the command
+# This image should be accessible from mesos slave i.e mesos slave
+# should be able to pull this docker image before executing the command.
+# docker_image_slave = puckel/docker-airflow
 
 [kerberos]
 ccache = /tmp/airflow_krb5_ccache
@@ -349,7 +423,91 @@ keytab = airflow.keytab
 [github_enterprise]
 api_rev = v3
 
-
 [admin]
 # UI to hide sensitive variable fields when set to True
 hide_sensitive_variable_fields = True
+
+[elasticsearch]
+elasticsearch_host =
+# we need to escape the curly braces by adding an additional curly brace
+elasticsearch_log_id_template = {{dag_id}}-{{task_id}}-{{execution_date}}-{{try_number}}
+elasticsearch_end_of_log_mark = end_of_log
+
+[kubernetes]
+# The repository, tag and imagePullPolicy of the Kubernetes Image for the Worker to Run
+worker_container_repository =
+worker_container_tag =
+worker_container_image_pull_policy = IfNotPresent
+worker_dags_folder =
+
+# If True (default), worker pods will be deleted upon termination
+delete_worker_pods = True
+
+# The Kubernetes namespace where airflow workers should be created. Defaults to `default`
+namespace = default
+
+# The name of the Kubernetes ConfigMap Containing the Airflow Configuration (this file)
+airflow_configmap =
+
+# For either git sync or volume mounted DAGs, the worker will look in this subpath for DAGs
+dags_volume_subpath =
+
+# For DAGs mounted via a volume claim (mutually exclusive with volume claim)
+dags_volume_claim =
+
+# For volume mounted logs, the worker will look in this subpath for logs
+logs_volume_subpath =
+
+# A shared volume claim for the logs
+logs_volume_claim =
+
+# Git credentials and repository for DAGs mounted via Git (mutually exclusive with volume claim)
+git_repo =
+git_branch =
+git_user =
+git_password =
+git_subpath =
+
+# For cloning DAGs from git repositories into volumes: https://github.com/kubernetes/git-sync
+git_sync_container_repository = gcr.io/google-containers/git-sync-amd64
+git_sync_container_tag = v2.0.5
+git_sync_init_container_name = git-sync-clone
+
+# The name of the Kubernetes service account to be associated with airflow workers, if any.
+# Service accounts are required for workers that require access to secrets or cluster resources.
+# See the Kubernetes RBAC documentation for more:
+#   https://kubernetes.io/docs/admin/authorization/rbac/
+worker_service_account_name =
+
+# Any image pull secrets to be given to worker pods, If more than one secret is
+# required, provide a comma separated list: secret_a,secret_b
+image_pull_secrets =
+
+# GCP Service Account Keys to be provided to tasks run on Kubernetes Executors
+# Should be supplied in the format: key-name-1:key-path-1,key-name-2:key-path-2
+gcp_service_account_keys =
+
+# Use the service account kubernetes gives to pods to connect to kubernetes cluster.
+# It's intended for clients that expect to be running inside a pod running on kubernetes.
+# It will raise an exception if called from a process not running in a kubernetes environment.
+in_cluster = True
+
+[kubernetes_node_selectors]
+# The Key-value pairs to be given to worker pods.
+# The worker pods will be scheduled to the nodes of the specified key-value pairs.
+# Should be supplied in the format: key = value
+
+[kubernetes_secrets]
+# The scheduler mounts the following secrets into your workers as they are launched by the
+# scheduler. You may define as many secrets as needed and the kubernetes launcher will parse the
+# defined secrets and mount them as secret environment variables in the launched workers.
+# Secrets in this section are defined as follows
+#     <environment_variable_mount> = <kubernetes_secret_object>:<kubernetes_secret_key>
+#
+# For example if you wanted to mount a kubernetes secret key named `postgres_password` from the
+# kubernetes secret object `airflow-secret` as the environment variable `POSTGRES_PASSWORD` into
+# your workers you would follow the following format:
+#     POSTGRES_PASSWORD = airflow-secret:postgres_credentials
+#
+# Additionally you may override worker airflow settings with the AIRFLOW__<SECTION>__<KEY>
+# formatting as supported by airflow normally.

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -22,6 +22,10 @@ encrypt_s3_logs = False
 # DEPRECATED option for remote log storage, use remote_base_log_folder instead!
 s3_log_folder =
 
+# Default timezone in case supplied date times are naive
+# can be utc (default), system, or any IANA timezone string (e.g. Europe/Amsterdam)
+default_timezone = system
+
 # The executor class that airflow should use. Choices include
 # SequentialExecutor, LocalExecutor, CeleryExecutor
 executor = LocalExecutor


### PR DESCRIPTION
Due to the upgrade to Airflow from v1.9 to v1.10, there are some issues with timezone, see
<https://stackoverflow.com/questions/48194000/apache-airflow-1-9-default-timezone-set-to-non-utc> for more information.

By recommendation, the `default_timezone` should be UTC, which is now set explicitly in this repo `airflow.cfg`. This is a breaking change if the downstream code assumes that the datetime passed into the DAG task function is a naive/system datetime. All other missing fields are matched against <https://github.com/apache/incubator-airflow/blob/1.10.0/airflow/config_templates/default_airflow.cfg>. 