### PR TITLE
Fix Flask-AppBuilder dependency issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN set -ex \
         /var/tmp/* \
         /usr/share/doc \
         /usr/share/doc-base \
-    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto, celery]==1.10.0" "celery[redis]>=4.1.1,<4.2.0" psycopg2
+    && SLUGIFY_USES_TEXT_UNIDECODE=yes pip install --no-cache-dir "apache-airflow[devel_hadoop, crypto, celery]==1.10.0" "celery[redis]>=4.1.1,<4.2.0" psycopg2 \
+    && pip install Flask-AppBuilder==1.11.1
 
 ARG airflow_home=/airflow
 ENV AIRFLOW_HOME=${airflow_home}


### PR DESCRIPTION
Revert to version 1.11 as 1.12 breaks due to bug with fab rbac for airflow admin ui.