### PR TITLE
fix: chown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ longer trigger any of the convenient environment variables / functionalities.
 The above convenience functionalities include:
 
 1. Discovering if database (`sqlite` and `postgres`) is ready
-2. Automatically running `airflow initdb`
+2. Automatically running `airflow db init` and `airflow db upgrade`
 3. Easy creation of Airflow Web UI admin user by simple env vars.
 
 See [`entrypoint.sh`](entrypoint.sh) for more details

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        AIRFLOW_VERSION: "1.10"
-        SPARK_VERSION: "2.4.5"
-        HADOOP_VERSION: "3.1.0"
+        AIRFLOW_VERSION: "2.1"
+        SPARK_VERSION: "3.0.2"
+        HADOOP_VERSION: "3.2.0"
         SCALA_VERSION: "2.12"
         PYTHON_VERSION: "3.7"
         SQLALCHEMY_VERSION: "1.3"
@@ -19,8 +19,6 @@ services:
       AIRFLOW__CORE__FERNET_KEY: 8NE6O6RcTJpxcCkuKxOHOExzIJkXkeJKbRie03a69dI=
       AIRFLOW__CORE__EXECUTOR: SequentialExecutor
       AIRFLOW__SCHEDULER__MAX_THREADS: "1"
-      # Enable RBAC since this is now the recommended default UI mode
-      AIRFLOW__WEBSERVER__RBAC: "true"
       ENABLE_AIRFLOW_RBAC_SETUP_AUTH: "true"
       AIRFLOW_WEBSERVER_RBAC_USER: admin
       AIRFLOW_WEBSERVER_RBAC_PASSWORD: Password123

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,8 +38,6 @@ fi
 # This possibly changes the log directory that might be mounted in
 if check_set "${ENABLE_AIRFLOW_CHOWN}"; then
   echo "Chowning ${AIRFLOW_HOME} to ${AIRFLOW_USER}:${AIRFLOW_GROUP}..."
-  mkdir -pv "${AIRFLOW_HOME}/dags"; \
-  mkdir -pv "${AIRFLOW_HOME}/logs"; \
   chown -R "${AIRFLOW_USER}:${AIRFLOW_GROUP}" "${AIRFLOW_HOME}/"
   echo "Chowning done!"
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,11 @@ fi
 # This possibly changes the log directory that might be mounted in
 if check_set "${ENABLE_AIRFLOW_CHOWN}"; then
   echo "Chowning ${AIRFLOW_HOME} to ${AIRFLOW_USER}:${AIRFLOW_GROUP}..."
-  chown "${AIRFLOW_USER}:${AIRFLOW_GROUP}" -R "${AIRFLOW_HOME}/"
+  mkdir -pv "${AIRFLOW_HOME}/dags"; \
+  mkdir -pv "${AIRFLOW_HOME}/logs"; \
+  chown -R "${AIRFLOW_USER}:${AIRFLOW_GROUP}" "${AIRFLOW_HOME}/"
+  find "${AIRFLOW_HOME}" -executable -print0 | xargs --null chmod g+x && \
+      find "${AIRFLOW_HOME}" -print0 | xargs --null chmod g+rw
   echo "Chowning done!"
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,8 +41,6 @@ if check_set "${ENABLE_AIRFLOW_CHOWN}"; then
   mkdir -pv "${AIRFLOW_HOME}/dags"; \
   mkdir -pv "${AIRFLOW_HOME}/logs"; \
   chown -R "${AIRFLOW_USER}:${AIRFLOW_GROUP}" "${AIRFLOW_HOME}/"
-  find "${AIRFLOW_HOME}" -executable -print0 | xargs --null chmod g+x && \
-      find "${AIRFLOW_HOME}" -print0 | xargs --null chmod g+rw
   echo "Chowning done!"
 fi
 
@@ -78,7 +76,7 @@ if check_set "${ENABLE_AIRFLOW_SETUP_AUTH}"; then
   echo "Admin user added!"
 fi
 
-AIRFLOW_VERSION="$(airflow version)"
+AIRFLOW_VERSION="$(gosu "${AIRFLOW_USER}" airflow version)"
 AIRFLOW_X_VERSION="$(echo ${AIRFLOW_VERSION} | cut -d . -f 1)"
 AIRFLOW_Y_VERSION="$(echo ${AIRFLOW_VERSION} | cut -d . -f 2)"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,8 @@ if check_set "${ENABLE_AIRFLOW_ADD_USER_GROUP}"; then
   echo "Adding Airflow user \"${AIRFLOW_USER}\" and group \"${AIRFLOW_GROUP}\"..."
   addgroup "${AIRFLOW_GROUP}"
   adduser --gecos "" --disabled-password --ingroup "${AIRFLOW_GROUP}" "${AIRFLOW_USER}"
+  find "${AIRFLOW_HOME}" -executable -print0 | xargs --null chmod g+x && \
+      find "${AIRFLOW_HOME}" -print0 | xargs --null chmod g+rw
   echo "Airflow user and group added successfully!"
 else
   AIRFLOW_USER="$(id -nu)"
@@ -38,7 +40,9 @@ fi
 # This possibly changes the log directory that might be mounted in
 if check_set "${ENABLE_AIRFLOW_CHOWN}"; then
   echo "Chowning ${AIRFLOW_HOME} to ${AIRFLOW_USER}:${AIRFLOW_GROUP}..."
-  chown -R "${AIRFLOW_USER}:${AIRFLOW_GROUP}" "${AIRFLOW_HOME}/"
+  mkdir -pv "${AIRFLOW_HOME}/dags"; \
+  mkdir -pv "${AIRFLOW_HOME}/logs"; \
+  chown -R "${AIRFLOW_USER}:root" "${AIRFLOW_HOME}/"
   echo "Chowning done!"
 fi
 


### PR DESCRIPTION
Note: the Airflow repo now has its own supported production Dockerfile.

Taken from https://github.com/apache/airflow/pull/9545/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R344-R351