### PR TITLE
fix(entrypoint): allow ignoring user and group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,17 @@ Add Airflow builds for v2.2 and v2.3.
 
 Remove support for builds with Airflow v1.9 and Spark v2.
 
+All previous deprecated commands linked to environment variables are updated:
+
+- `ENABLE_AIRFLOW_INITDB`
+  - `airflow initdb` -> `airflow db init`
+- `ENABLE_AIRFLOW_UPGRADEDB`
+  - `airflow upgradedb` -> `airflow db upgrade`
+
 Update `entrypoint.sh` to support the new version of Airflow.
+
+Fix `entrypoint.sh` to skip creation of `${AIRFLOW_USER}` and `${AIRFLOW_GROUP}`
+if they already exist in the system.
 
 ### BREAKING CHANGES
 

--- a/docker-compose.split.yml
+++ b/docker-compose.split.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   postgres:
     image: postgres:9.6
@@ -8,6 +7,11 @@ services:
       POSTGRES_USER: fixme
       POSTGRES_PASSWORD: fixme
       POSTGRES_DB: airflow
+    healthcheck:
+      test: ["pg_isready"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     restart: always
   scheduler:
     depends_on:
@@ -16,24 +20,34 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        AIRFLOW_VERSION: "1.10"
-        SPARK_VERSION: "3.0.0-preview2-rc2"
-        HADOOP_VERSION: "3.2.0"
-        PYTHON_VERSION: "3.6"
-        SQLALCHEMY_VERSION: "1.3"
-    command: ["bash", "-c", "python test_db_conn.py && airflow initdb && airflow scheduler"]
+        AIRFLOW_VERSION: "2.3"
+        SPARK_VERSION: "3.3.0"
+        HADOOP_VERSION: "3.3.2"
+        SCALA_VERSION: "2.12"
+        JAVA_VERSION: "11"
+        PYTHON_VERSION: "3.9"
+        SQLALCHEMY_VERSION: "1.4"
+    command: ["bash", "-c", "python test_db_conn.py && airflow db init && airflow scheduler"]
     volumes:
       - airflow_logs:/airflow/logs/
     environment: &environment
+      ENABLE_AIRFLOW_INITDB: "true"
+      ENABLE_AIRFLOW_UPGRADEDB: "true"
       AIRFLOW__CORE__FERNET_KEY: 8NE6O6RcTJpxcCkuKxOHOExzIJkXkeJKbRie03a69dI=
       AIRFLOW__CORE__SQL_ALCHEMY_CONN: postgresql://fixme:fixme@postgres:5432/airflow
       AIRFLOW__CORE__EXECUTOR: LocalExecutor
+      ENABLE_AIRFLOW_RBAC_SETUP_AUTH: "true"
+      AIRFLOW_WEBSERVER_RBAC_USER: admin
+      AIRFLOW_WEBSERVER_RBAC_PASSWORD: Password123
+      AIRFLOW_WEBSERVER_RBAC_EMAIL: admin-san@xyz.com
+      AIRFLOW_WEBSERVER_RBAC_FIRST_NAME: admin
+      AIRFLOW_WEBSERVER_RBAC_LAST_NAME: san
     restart: always
   webserver:
     depends_on:
       - postgres
     build: *build
-    command: ["bash", "-c", "sleep 7 && airflow webserver"]
+    command: ["airflow", "webserver"]
     ports:
       - 8080:8080
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,16 @@
-version: '2.3'
 services:
   airflow:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        AIRFLOW_VERSION: "2.1"
-        SPARK_VERSION: "3.0.2"
-        HADOOP_VERSION: "3.2.0"
+        AIRFLOW_VERSION: "2.3"
+        SPARK_VERSION: "3.3.0"
+        HADOOP_VERSION: "3.3.2"
         SCALA_VERSION: "2.12"
-        PYTHON_VERSION: "3.7"
-        SQLALCHEMY_VERSION: "1.3"
+        JAVA_VERSION: "11"
+        PYTHON_VERSION: "3.9"
+        SQLALCHEMY_VERSION: "1.4"
     ports:
       - 8080:8080
     environment:


### PR DESCRIPTION
`entrypoint.sh` can now skip creation of `$AIRFLOW_USER` and
`$AIRFLOW_GROUP` if they already exist, even if
`$ENABLE_AIRFLOW_ADD_USER_GROUP` was set to `true`.